### PR TITLE
Correct the env to set the CPATH in

### DIFF
--- a/wscript
+++ b/wscript
@@ -60,12 +60,13 @@ def configure(conf):
              conf.env.INCLUDES_FFTW3 = conf.options.fftw_path+'/include'
         else:
            # Try to use pkg-config to find the FFTW library.
-           cpath = conf.env.CPATH
+           oenv = conf.env.env
            # Empty the CPATH for pkg-config, as it will be ignored by the Fortran compiler
-           conf.env.CPATH = ''
+           conf.env.env = dict(conf.environ)
+           conf.env.env['CPATH'] = ''
            conf.check_cfg(package='fftw3', uselib_store='FFTW3',
                           args=['--cflags', '--libs'], mandatory=False)
-           conf.env.CPATH = cpath
+           conf.env.env = oenv
            if not conf.env.LIB_FFTW3:
               # Try to link the fftw without any further options.
               conf.check(lib='fftw3', uselib_store='FFTW3', mandatory=False)


### PR DESCRIPTION
The CPATH environment variable has to be set in the env.env for the pkg-config check.