### PR TITLE
Fftw includes

### DIFF
--- a/wscript
+++ b/wscript
@@ -78,7 +78,7 @@ def configure(conf):
            conf.all_envs[''].FCFLAGS_FFTW3 = conf.env.CFLAGS_FFTW3
            conf.all_envs[''].LIB_FFTW3 = conf.env.LIB_FFTW3
            conf.all_envs[''].LIBPATH_FFTW3 = conf.env.LIBPATH_FFTW3
-           conf.all_envs[''].INCLUDES_FFTW3 = FFTW_INCLUDES #conf.env.INCLUDES_FFTW3
+           conf.all_envs[''].INCLUDES_FFTW3 = FFTW_INCLUDES
         conf.setenv('')
 
     if conf.env.LIB_FFTW3:

--- a/wscript
+++ b/wscript
@@ -81,6 +81,7 @@ def configure(conf):
     if conf.env.LIB_FFTW3:
        try:
          # Check for the fftw3.f03 header:
+         Logs.info(f'FFTW include dir: {conf.env.INCLUDES_FFTW3}')
          if conf.env.LIB_ASL:
            conf.check_fc(fragment= "program test\n use, intrinsic :: iso_c_binding\n include 'aslfftw3.f03'\nend program test",
                          includes= conf.env.INCLUDES_FFTW3,

--- a/wscript
+++ b/wscript
@@ -81,7 +81,8 @@ def configure(conf):
     if conf.env.LIB_FFTW3:
        try:
          # Check for the fftw3.f03 header:
-         Logs.info(f'FFTW include dir: {conf.env.INCLUDES_FFTW3}')
+         conf.env.INCLUDES_FFTW3.append('/usr/include')
+         Logs.info(f'FFTW include dirs: {conf.env.INCLUDES_FFTW3}')
          if conf.env.LIB_ASL:
            conf.check_fc(fragment= "program test\n use, intrinsic :: iso_c_binding\n include 'aslfftw3.f03'\nend program test",
                          includes= conf.env.INCLUDES_FFTW3,

--- a/wscript
+++ b/wscript
@@ -72,16 +72,18 @@ def configure(conf):
               conf.check(lib='fftw3', uselib_store='FFTW3', mandatory=False)
 
         if conf.env.LIB_FFTW3:
+           FFTW_INCLUDES = conf.env.INCLUDES_FFTW3
+           if len(conf.env.INCLUDES_FFTW3) == 0:
+             FFTW_INCLUDES.append('/usr/include')
            conf.all_envs[''].FCFLAGS_FFTW3 = conf.env.CFLAGS_FFTW3
            conf.all_envs[''].LIB_FFTW3 = conf.env.LIB_FFTW3
            conf.all_envs[''].LIBPATH_FFTW3 = conf.env.LIBPATH_FFTW3
-           conf.all_envs[''].INCLUDES_FFTW3 = conf.env.INCLUDES_FFTW3
+           conf.all_envs[''].INCLUDES_FFTW3 = FFTW_INCLUDES #conf.env.INCLUDES_FFTW3
         conf.setenv('')
 
     if conf.env.LIB_FFTW3:
        try:
          # Check for the fftw3.f03 header:
-         conf.env.INCLUDES_FFTW3.append('/usr/include')
          Logs.info(f'FFTW include dirs: {conf.env.INCLUDES_FFTW3}')
          if conf.env.LIB_ASL:
            conf.check_fc(fragment= "program test\n use, intrinsic :: iso_c_binding\n include 'aslfftw3.f03'\nend program test",


### PR DESCRIPTION
On Ubuntu (Debian) systems (and possibly others), the FFTW Fortran include files get installed into a system include directory and pkg-config does not provide an include path option at all. The unsetting of CPATH in the wscript there does not help. Hence, we need to deal with the lack of an include path for the Fortran compiler in this case.
