### PR TITLE
Apply min_dofs also for p-space conversion

### DIFF
--- a/source/ply_oversample_module.fpp
+++ b/source/ply_oversample_module.fpp
@@ -317,6 +317,7 @@ contains
     integer :: nScalars
     integer :: iVar
     integer :: mpd1, mpd1_square, mpd1_cube
+    integer :: p_mindofs
     integer :: iDegX, iDegY, iDegZ, idof, dof, dofOverSamp
     ! -------------------------------------------------------------------- !
 
@@ -349,7 +350,8 @@ contains
       iDegX = 1
       iDegY = 1
       iDegZ = 1
-      do idof = 1, poly_proj%body_3d%min_dofs
+      p_mindofs = min(poly_proj%body_3d%min_dofs, (mpd1*(mpd1+1)*(mpd1+2))/6)
+      do idof = 1, p_mindofs
 ?? copy :: posOfModgCoeffPTens(iDegX, iDegY, iDegZ, dof)
         dofOverSamp = iDegX + ( iDegY-1  &
           &                     + (iDegZ-1)*(oversamp_degree+1) &
@@ -544,6 +546,7 @@ contains
     ! -------------------------------------------------------------------- !
     integer :: oversamp_degree
     integer :: mpd1, mpd1_square
+    integer :: p_mindofs
     integer :: iDegX, iDegY, iDegZ, idof, dof, dofOverSamp, nPVars
     ! -------------------------------------------------------------------- !
     ! Information for the oversampling loop
@@ -572,7 +575,8 @@ contains
       iDegX = 1
       iDegY = 1
       iDegZ = 0 ! not used in posOfModgCoeffPTens_2D, nextModgCoeffPTens
-      do idof = 1, poly_proj%body_2d%min_dofs
+      p_mindofs = min(poly_proj%body_2d%min_dofs, (mpd1*(mpd1+1))/2)
+      do idof = 1, p_mindofs
 ?? copy :: posOfModgCoeffPTens2D(iDegX, iDegY, dof)
         dofOverSamp = iDegX + (iDegY-1)*(oversamp_degree+1)
         state(dof,1:nPVars) = modalCoeffs(dofOverSamp,1:nPVars)


### PR DESCRIPTION
The projection in p-polynomials did not heed reduced polynomial degrees that the caller requested for the resulting array and thus, potentially assumed wrong array sizes.
This problem has now been fixed and only the requested dofs will be filled in the conversion back from the oversampled data.